### PR TITLE
chore(github-action): use generic configuration for tgz file name

### DIFF
--- a/.github/workflows/on-PRs-commits.yml
+++ b/.github/workflows/on-PRs-commits.yml
@@ -110,4 +110,4 @@ jobs:
         with:
           name: archive-bosh-dev-release-tgz
           path: |
-            k3s-*.tgz
+            ./${{ steps.create-bosh-release.outputs.file }}


### PR DESCRIPTION
we use bosh release tgz generated by create release action for archiving